### PR TITLE
Allow passing of File objects to Page.new

### DIFF
--- a/lib/harmony/page.rb
+++ b/lib/harmony/page.rb
@@ -26,7 +26,12 @@ module Harmony
       end
 
       def from_document(document)
-        Tempfile.open('harmony') {|f| f << document; @path = f.path }
+        # Allow passing of File objects: Harmony::Page.new(open('index.html'))
+        if document.is_a? File
+          @path = File.expand_path document.path
+        else
+          Tempfile.open('harmony') {|f| f << document; @path = f.path }
+        end
         from_uri("file://#{@path}")
       end
 


### PR DESCRIPTION
This patch allows for the passing of `File` objects, which means that html files can be processed in-place, so references to relative files will be in-tact, rather than Harmony trying to find them in the temporary directories.
## Background

Why did I build this? While I was playing with RightJS in Harmony I noticed that doing `harmony_page.load('right.js')` [threw errors](http://rightjs.lighthouseapp.com/projects/31989/tickets/339-weirdness-with-tracemonkey#ticket-339-1) — this was because RightJS expects itself to feature in the list of `<script>` tags — it appears that `#load` doesn't inject the javascript in that way so it was having a rough time.

With this patch I can now create an HTML loader file and do `Harmony::Page.new(open('loader.html'))`, but I'd really like Harmony/Johnson to look for references in the current ruby working directory too, if anyone knows how that could be achieved? Here's an example:

```
require 'harmony'
# => true 
File.exists?('right.js')
# => true
page = Harmony::Page.new <<-eHTML
<html><head><script src="right.js"></script></head><body></body></html>
eHTML
# WARNIING: [Wed Sep 08 2010 12:32:57 GMT+0100 (BST)] {ENVJS} could not load script /var/folders/0g/0gCwWYT-HeGprEfdSvQmDU+++TI/-Tmp-/right.js: No such file or directory - /var/folders/0g/0gCwWYT-HeGprEfdSvQmDU+++TI/-Tmp-/right.js
# => #<Harmony::Page:0x101847f40 @window=[object Window 1]> 
```
