### PR TITLE
Rails3

### DIFF
--- a/lib/harmony/page.rb
+++ b/lib/harmony/page.rb
@@ -73,7 +73,9 @@ module Harmony
     #
     def load(*paths)
       paths.flatten.each do |path|
-        window.load(path.to_s)
+        path.to_s.map {|f|
+          window.evaluate(File.read(f).gsub(/\A#!.*$/, ''), f, 1)
+        }.last
       end
       self
     end


### PR DESCRIPTION
Removing window.load, this patch will make harmony works properly with rails 3.

see this pastie for more information: http://pastie.org/private/o6sri73teazpf3dv3eq
